### PR TITLE
fix : "크루조회"에서 request가 여러 개일 경우 userDto 중복

### DIFF
--- a/src/main/java/toyproject/runningmate/service/CrewService.java
+++ b/src/main/java/toyproject/runningmate/service/CrewService.java
@@ -55,7 +55,6 @@ public class CrewService {
         Crew crew = em.createQuery(
                 "select distinct c from Crew c" +
                         " join fetch c.users" +
-                        " left outer join fetch c.requests" +
                         " where c.crewName = :name", Crew.class)
                 .setParameter("name", crewName)
                 .getSingleResult();


### PR DESCRIPTION
request가 여러 개일 경우 left outer join으로 인해 userDto가 중복 반환
request는 join하지 않고 따로 데이터를 주입해주는 방식으로 변경